### PR TITLE
Expose target tag to Promote task

### DIFF
--- a/src/main/groovy/com/cdancy/gradle/artifactory/rest/ArtifactoryRestPlugin.groovy
+++ b/src/main/groovy/com/cdancy/gradle/artifactory/rest/ArtifactoryRestPlugin.groovy
@@ -27,7 +27,7 @@ import org.gradle.api.artifacts.Configuration
  */
 class ArtifactoryRestPlugin implements Plugin<Project> {
     public static final String ARTIFACTORY_CONFIGURATION_NAME = 'artifactoryRest'
-    public static final String ARTIFACTORY_REST_DEFAULT_VERSION = '0.9.5'
+    public static final String ARTIFACTORY_REST_DEFAULT_VERSION = '0.9.8'
     public static final String EXTENSION_NAME = 'artifactoryRest'
     public static final String DEFAULT_TASK_GROUP = 'ArtifactoryRest'
 
@@ -42,7 +42,7 @@ class ArtifactoryRestPlugin implements Plugin<Project> {
         ArtifactoryRestExtension extension = project.extensions.create(EXTENSION_NAME, ArtifactoryRestExtension)
 		configureAbstractArtifactoryTask(project, extension)
     }
-	
+
     private void configureAbstractArtifactoryTask(Project project, ArtifactoryRestExtension extension) {
         ThreadContextClassLoader artifactoryClassLoader = new ArtifactoryRestThreadContextClassLoader(extension, configurePluginClassPath(project))
         project.tasks.withType(AbstractArtifactoryRestTask) {

--- a/src/main/groovy/com/cdancy/gradle/artifactory/rest/tasks/docker/Promote.groovy
+++ b/src/main/groovy/com/cdancy/gradle/artifactory/rest/tasks/docker/Promote.groovy
@@ -18,6 +18,7 @@ package com.cdancy.gradle.artifactory.rest.tasks.docker
 import com.cdancy.gradle.artifactory.rest.tasks.ArtifactAware
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 
 class Promote extends ArtifactAware {
 
@@ -31,12 +32,16 @@ class Promote extends ArtifactAware {
     Closure<String> tag
 
     @Input
+    @Optional
+    Closure<String> targetTag
+
+    @Input
     boolean copy
 
     @Override
     void runRemoteCommand(artifactoryClient) {
         def api = artifactoryClient.api().dockerApi()
-        def dockerPromote = threadContextClassLoader.newPromote(promotedRepo(), image(), tag(), copy)
+        def dockerPromote = threadContextClassLoader.newPromote(promotedRepo(), image(), tag(), targetTag(), copy)
         boolean success = api.promote(repo().toString(), dockerPromote)
         if (success) {
             logger.quiet("Successfully promoted image @ ${repo()}/${image()}:${tag()} to ${promotedRepo()}")
@@ -69,6 +74,15 @@ class Promote extends ArtifactAware {
             var
         } else {
             throw new GradleException("tag does not resolve to a valid String: tag=" + var)
+        }
+    }
+
+    private String targetTag() {
+        String var = targetTag ? targetTag.call() : null
+        if (!var || var?.trim()) {
+            var
+        } else {
+            throw new GradleException("targetTag does not resolve to a valid String: tag=" + var)
         }
     }
 }

--- a/src/main/groovy/com/cdancy/gradle/artifactory/rest/utils/ArtifactoryRestThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/cdancy/gradle/artifactory/rest/utils/ArtifactoryRestThreadContextClassLoader.groovy
@@ -48,7 +48,7 @@ class ArtifactoryRestThreadContextClassLoader implements ThreadContextClassLoade
         closure.delegate = this
         closure(artifactoryClient)
     }
-	
+
     private def generateClient() {
 
         // These can be null but if so then System Properties and
@@ -72,7 +72,7 @@ class ArtifactoryRestThreadContextClassLoader implements ThreadContextClassLoade
             .endPoint(foundEndPoint)
             .credentials(foundCredentials)
             .overrides(foundOverrides)
-            .build();        
+            .build();
     }
 
     @Override
@@ -82,9 +82,10 @@ class ArtifactoryRestThreadContextClassLoader implements ThreadContextClassLoade
         method.invoke(null, file);
     }
 
-    def newPromote(String promotedRepo, String image, String tag, boolean copy) {
+    @Override
+    def newPromote(String promotedRepo, String image, String tag, String targetTag, boolean copy) {
         Class clazz = ArtifactoryRestUtil.loadClass(artifactoryClient.class.classLoader, PROMOTE_CLASS)
-        Method method = clazz.getMethod("create", String, String, String, boolean);
-        method.invoke(null, promotedRepo, image, tag, copy);
+        Method method = clazz.getMethod("create", String, String, String, String, boolean);
+        method.invoke(null, promotedRepo, image, tag, targetTag, copy);
     }
 }

--- a/src/main/groovy/com/cdancy/gradle/artifactory/rest/utils/ThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/cdancy/gradle/artifactory/rest/utils/ThreadContextClassLoader.groovy
@@ -16,7 +16,7 @@
 package com.cdancy.gradle.artifactory.rest.utils
 
 interface ThreadContextClassLoader {
-	
+
     /**
      * Performs the closure with thread context classloader.
      *
@@ -26,5 +26,5 @@ interface ThreadContextClassLoader {
 
     def newPayload(Object resource)
 
-    def newPromote(String promotedRepo, String image, String tag, boolean copy)
+    def newPromote(String promotedRepo, String image, String tag, String targetTag, boolean copy)
 }

--- a/src/test/groovy/com/cdancy/gradle/artifactory/rest/tasks/docker/PromoteTest.groovy
+++ b/src/test/groovy/com/cdancy/gradle/artifactory/rest/tasks/docker/PromoteTest.groovy
@@ -1,0 +1,106 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2020  Pegasystems Inc.
+ * All rights reserved.
+ *
+ * This  software  has  been  provided pursuant  to  a  License
+ * Agreement  containing  restrictions on  its  use.   The  software
+ * contains  valuable  trade secrets and proprietary information  of
+ * Pegasystems Inc and is protected by  federal   copyright law.  It
+ * may  not be copied,  modified,  translated or distributed in  any
+ * form or medium,  disclosed to third parties or used in any manner
+ * not provided for in  said  License Agreement except with  written
+ * authorization from Pegasystems Inc.
+*/
+package com.cdancy.gradle.artifactory.rest.tasks.docker
+
+import com.cdancy.gradle.artifactory.rest.ArtifactoryRestPlugin
+import com.cdancy.gradle.artifactory.rest.utils.ThreadContextClassLoader
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+/**
+ *
+ * @author vagrant* @version $Id$ 3/5/20
+ */
+class PromoteTest extends Specification {
+    Project project
+    Promote promoteTask
+    ThreadContextClassLoader threadContextClassLoader
+    ArtifactoryClient artifactoryClient
+    ArtifactoryApi artifactoryApi
+    ArtifactoryDockerApi dockerApi
+
+    def 'promotes image'() {
+        given:
+        dockerApi.promote('source-repo', _) >> true
+
+        when:
+        promoteTask.runRemoteCommand(artifactoryClient)
+
+        then:
+        1 * threadContextClassLoader.newPromote(
+            'target-repo',
+            'test/image',
+            '1.0.0',
+            null,
+            false)
+    }
+
+    def 'promotes image with target tag'() {
+        given:
+        promoteTask.targetTag = { 'latest' }
+        dockerApi.promote('source-repo', _) >> true
+
+        when:
+        promoteTask.runRemoteCommand(artifactoryClient)
+
+        then:
+        1 * threadContextClassLoader.newPromote(
+            'target-repo',
+            'test/image',
+            '1.0.0',
+            'latest',
+            false)
+    }
+
+    def setup() {
+        project = ProjectBuilder.builder().withName('root').build()
+        project.plugins.apply ArtifactoryRestPlugin
+        promoteTask = project.tasks.create('promoteImage', Promote) {
+            repo = { 'source-repo' }
+            promotedRepo = { 'target-repo' }
+            image = { 'test/image' }
+            tag = { '1.0.0' }
+        }
+
+        artifactoryClient = Mock()
+        artifactoryApi = Mock()
+        dockerApi = Mock()
+        threadContextClassLoader = Mock()
+
+        artifactoryClient.api() >> artifactoryApi
+        artifactoryApi.dockerApi() >> dockerApi
+        threadContextClassLoader.newPromote(_, _, _, _, _) >> Mock(PromoteImage)
+
+        promoteTask.threadContextClassLoader = threadContextClassLoader
+    }
+
+    interface ArtifactoryClient {
+        ArtifactoryApi api()
+    }
+
+    interface ArtifactoryApi {
+        ArtifactoryDockerApi dockerApi()
+    }
+
+    interface ArtifactoryDockerApi {
+        boolean promote(String repo, Object promoteImage)
+    }
+
+    interface PromoteImage {
+
+    }
+}


### PR DESCRIPTION
Expose the ability to set the targetTag when promoting docker images via the Promote task
* update rest lib version to 0.9.8
* expose targetTag as an optional closure in the Promote task

See https://www.jfrog.com/confluence/display/JFROG/Docker+Registry
![Screenshot from 2020-03-05 07-55-21](https://user-images.githubusercontent.com/54679517/75996578-0d6fee00-5ecc-11ea-8c10-c6e25b52005a.png)
